### PR TITLE
Fix name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 BINARY := kubedeploy
 LDFLAGS := -ldflags="-s -w"
 
-bin/kubenetes-slack:
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/kubedeploy
+bin/$(BINARY):
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/$(BINARY)
 
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
## WHY

Fix typo.

:x: kubernetes-slack
:o: $(BINARY)
