### PR TITLE
Fix and Refactoring repalceImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,7 @@ RUN apk add --no-cache --update --virtual=build-deps curl git go make  \
   && go get -v ./... \
   && make \
   && cp bin/kubedeploy /kubedeploy \
-  && wget -qO /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-  && chmod +x /usr/local/bin/kubectl \
   && cd / \
-  && apk del --purge wget \
   && apk del build-deps \
   && rm /var/cache/apk/* \
   && rm -rf /go

--- a/deploy.go
+++ b/deploy.go
@@ -50,7 +50,7 @@ func deploy(kubeClient *client.Client, params map[string]string) {
 	}
 
 	// chenge blue-green
-	replaceColor(service)
+	replaceColor(kubeClient, service)
 
 	// check color
 	service = getTargetService(kubeClient, params["service"], params["namespace"])

--- a/utils.go
+++ b/utils.go
@@ -1,18 +1,6 @@
 package main
 
-import (
-	"log"
-	"os/exec"
-	"strings"
-)
-
-func execOutput(app string, commands []string) string {
-	out, err := exec.Command(app, commands...).Output()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return string(out)
-}
+import "strings"
 
 func trimImageName(imageName string) string {
 	head := strings.Index(imageName, QUAYPATH)


### PR DESCRIPTION
## WHY

To replace pod's image, kubedeploy uses execOuput function. 
## WHAT

It uses API client.
